### PR TITLE
Handle carriage returns in source JSON whitespace

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,7 @@ where
 
             match char {
                 b'"' => in_string = true,
-                b' ' | b'\n' | b'\t' => continue,
+                b' ' | b'\n' | b'\r' | b'\t' => continue,
                 b'[' => {
                     indent_level += 1;
                     request_newline = true;
@@ -244,5 +244,22 @@ mod test {
 ";
 
         assert_eq!(expected, format(expected, Indentation::TwoSpace));
+    }
+
+    #[test]
+    fn contains_crlf() {
+        let json = "[\r\n{\r\n\"a\":0\r\n},\r\n{},\r\n{\r\n\"a\": null\r\n}\r\n]\r\n";
+        let expected = "[
+  {
+    \"a\": 0
+  },
+  {},
+  {
+    \"a\": null
+  }
+]
+";
+
+        assert_eq!(expected, format(json, Indentation::TwoSpace));
     }
 }


### PR DESCRIPTION
Previously any carriage return (\r) bytes in the JSON whitespace were not ignored. Instead they were included in the formatted output. This led to very bad formatting, as the indentation would include the carriage return.

With this change, carriage returns are handled the same way that newlines are: they are ignored in the source JSON whitespace.

It might be better to detect if the source JSON is using Windows (\r\n) newlines, and preserve that on the output. However, that is a much bigger change. For now I think it is sufficient to simply produce necely formatted output which uses only \n newlines.